### PR TITLE
Auto-expand subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### nova-trame, 0.22.0
+
+* DataSelector queries subdirectories on demand, which should improve performance for large directory trees (thanks to John Duggan).
+
 ### nova-trame, 0.21.0
 
 * ProgressBar component now displays detailed job status (thanks to Sergey Yakubov).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ Changelog = "https://code.ornl.gov/ndip/public-packages/nova-trame/blob/main/CHA
 
 [tool.poetry]
 name = "nova-trame"
-version = "0.21.0"
+version = "0.22.0"
 description = "A Python Package for injecting curated themes and custom components into Trame applications"
 authors = ["Duggan, John <dugganjw@ornl.gov>"]
 readme = "README.md"

--- a/src/nova/trame/view/components/data_selector.py
+++ b/src/nova/trame/view/components/data_selector.py
@@ -133,8 +133,10 @@ class DataSelector(datagrid.VGrid):
                             activatable=True,
                             active_strategy="single-independent",
                             classes="flex-1-0 h-0 overflow-y-auto",
+                            fluid=True,
                             item_value="path",
                             items=(self._directories_name,),
+                            click_open=(self._vm.expand_directory, "[$event.path]"),
                             update_activated=(self._vm.set_directory, "$event"),
                         )
                         vuetify.VListItem("No directories found", classes="flex-0-1 text-center", v_else=True)

--- a/src/nova/trame/view/theme/assets/core_style.scss
+++ b/src/nova/trame/view/theme/assets/core_style.scss
@@ -20,6 +20,14 @@ html {
     white-space: pre-wrap;
 }
 
+.nova-data-selector {
+    .v-list-group {
+        .v-treeview-item {
+            --indent-padding: 1em !important;
+        }
+    }
+}
+
 .nova-data-selector revo-grid {
     font-family: 'Roboto', sans-serif;
     font-size: 0.75rem !important;

--- a/src/nova/trame/view_model/data_selector.py
+++ b/src/nova/trame/view_model/data_selector.py
@@ -30,18 +30,23 @@ class DataSelectorViewModel:
         if paths[-1] in self.expanded:
             return
 
-        # TODO: refactor/clean this up as it's confusing
+        # Query for the new subdirectories to display in the view
         new_directories = self.model.get_directories(Path(paths[-1]))
-        current_level: Any = self.directories
-        for current_path in paths:
-            if isinstance(current_level, Dict):
-                current_level = current_level["children"]
 
-            for entry in current_level:
+        # Find the entry in the existing directories that corresponds to the directory to expand
+        current_level: Dict[str, Any] = {}
+        children: List[Dict[str, Any]] = self.directories
+        for current_path in paths:
+            if current_level:
+                children = current_level["children"]
+
+            for entry in children:
                 if current_path == entry["path"]:
                     current_level = entry
                     break
         current_level["children"] = new_directories
+
+        # Mark this directory as expanded and display the new content
         self.expanded.append(paths[-1])
         self.directories_bind.update_in_view(self.directories)
 
@@ -56,6 +61,7 @@ class DataSelectorViewModel:
     def reset(self) -> None:
         self.model.set_directory("")
         self.directories = self.model.get_directories()
+        self.expanded = []
         self.reset_bind.update_in_view(None)
 
     def on_state_updated(self, results: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
DataSelector will now only query two levels deep, but it will query another level deep when a directory is expanded. I've also tweaked the CSS to make it work with any level of nesting by removing the increasing indentation.

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [x] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
