### PR TITLE
Fix literalinclude blocks from tests directory

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -40,6 +40,8 @@ General Purpose Components
     :members:
     :special-members: __new__
 
+.. _api_remotefileinput:
+
 .. autoclass:: nova.trame.view.components.RemoteFileInput
     :members:
     :special-members: __init__

--- a/docs/example_layouts.rst
+++ b/docs/example_layouts.rst
@@ -9,7 +9,7 @@ GridLayout
 ----------
 By default, each item in a GridLayout will take up one row and one column. This can be changed by setting the row_span and column_span properties of the item.
 
-.. literalinclude:: ../tests/gallery/app.py
+.. literalinclude:: ../tests/gallery/views/app.py
     :start-after: grid row and column span example
     :end-before: grid row and column span example end
     :dedent:
@@ -25,7 +25,7 @@ GridLayout with whitespace
 --------------------------
 Trying this with HBoxLayout or VBoxLayout will produce unpredictable behavior.
 
-.. literalinclude:: ../tests/gallery/app.py
+.. literalinclude:: ../tests/gallery/views/app.py
     :start-after: whitespace example
     :end-before: whitespace example end
     :dedent:
@@ -40,7 +40,7 @@ Result:
 HBoxLayout containing VBoxLayout
 --------------------------------
 
-.. literalinclude:: ../tests/gallery/app.py
+.. literalinclude:: ../tests/gallery/views/app.py
     :start-after: mixed boxes example 1
     :end-before: mixed boxes example 1 end
     :dedent:
@@ -55,7 +55,7 @@ Result:
 VBoxLayout containing HBoxLayout
 --------------------------------
 
-.. literalinclude:: ../tests/gallery/app.py
+.. literalinclude:: ../tests/gallery/views/app.py
     :start-after: mixed boxes example 2
     :end-before: mixed boxes example 2 end
     :dedent:
@@ -70,7 +70,7 @@ Result:
 GridLayout containing BoxLayouts
 --------------------------------
 
-.. literalinclude:: ../tests/gallery/app.py
+.. literalinclude:: ../tests/gallery/views/app.py
     :start-after: mixed boxes example 3
     :end-before: mixed boxes example 3 end
     :dedent:

--- a/docs/working_with_trame.rst
+++ b/docs/working_with_trame.rst
@@ -42,7 +42,7 @@ If you want to customize a slot, you can either completely replace it or add chi
 
 If you want to add children to a slot, you can do the following:
 
-.. literalinclude:: ../tests/gallery/app.py
+.. literalinclude:: ../tests/gallery/views/app.py
     :start-after: slot child example
     :end-before: slot child example complete
     :dedent:
@@ -85,7 +85,7 @@ In order to use Vuetify helper classes in Trame, you can provide the `classes` a
 
 Example:
 
-.. literalinclude:: ../tests/gallery/app.py
+.. literalinclude:: ../tests/gallery/views/app.py
     :start-after: Vuetify class example start
     :end-before: Vuetify class example end
     :dedent:

--- a/src/nova/trame/view/components/input_field.py
+++ b/src/nova/trame/view/components/input_field.py
@@ -172,7 +172,7 @@ class InputField:
             The following example would set the auto_grow and label attributes on
             `VTextarea <https://trame.readthedocs.io/en/latest/trame.widgets.vuetify3.html#trame.widgets.vuetify3.VTextarea>`_:
 
-            .. literalinclude:: ../tests/gallery/app.py
+            .. literalinclude:: ../tests/gallery/views/app.py
                 :start-after: InputField kwargs example start
                 :end-before: InputField kwargs example end
                 :dedent:

--- a/src/nova/trame/view/layouts/grid.py
+++ b/src/nova/trame/view/layouts/grid.py
@@ -53,7 +53,7 @@ class GridLayout(html.Div):
         --------
         Basic usage:
 
-        .. literalinclude:: ../tests/gallery/app.py
+        .. literalinclude:: ../tests/gallery/views/app.py
             :start-after: setup grid
             :end-before: setup grid complete
             :dedent:
@@ -133,7 +133,7 @@ class GridLayout(html.Div):
 
         Example
         -------
-        .. literalinclude:: ../tests/gallery/app.py
+        .. literalinclude:: ../tests/gallery/views/app.py
             :start-after: grid row and column span example
             :end-before: grid row and column span example end
             :dedent:

--- a/src/nova/trame/view/layouts/hbox.py
+++ b/src/nova/trame/view/layouts/hbox.py
@@ -51,7 +51,7 @@ class HBoxLayout(html.Div):
 
         Example
         -------
-        .. literalinclude:: ../tests/gallery/app.py
+        .. literalinclude:: ../tests/gallery/views/app.py
             :start-after: setup hbox
             :end-before: setup hbox complete
             :dedent:

--- a/src/nova/trame/view/layouts/vbox.py
+++ b/src/nova/trame/view/layouts/vbox.py
@@ -51,7 +51,7 @@ class VBoxLayout(html.Div):
 
         Example
         -------
-        .. literalinclude:: ../tests/gallery/app.py
+        .. literalinclude:: ../tests/gallery/views/app.py
             :start-after: setup vbox
             :end-before: setup vbox complete
             :dedent:


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
Fixes the literalinclude references to the test application.

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [x] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->
https://nova-application-development.readthedocs.io/projects/nova-trame/en/latest/ has been updated. stable will be updated after merge.

## Additional Notes
<!-- Provide any additional information that might be relevant -->
