### PR TITLE
Implement ONCat backend for NeutronDataSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### nova-trame, 0.25.0
+
+* Added data_source and projection parameters to NeutronDataSelector to allow populating data files from ONCat (thanks to Andrew Ayres and John Duggan).
+
 ### nova-trame, 0.24.0
 
 * Parameters to DataSelector and NeutronDataSelector should now support bindings (thanks to John Duggan).

--- a/poetry.lock
+++ b/poetry.lock
@@ -251,7 +251,7 @@ version = "2025.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057"},
     {file = "certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"},
@@ -356,7 +356,7 @@ version = "3.4.2"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "charset_normalizer-3.4.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c48ed483eb946e6c04ccbe02c6b4d1d48e51944b6db70f697e089c193404941"},
     {file = "charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2d318c11350e10662026ad0eb71bb51c7812fc8590825304ae0bdd4ac283acd"},
@@ -1757,6 +1757,23 @@ files = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1"},
+    {file = "oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9"},
+]
+
+[package.extras]
+rsa = ["cryptography (>=3.0.0)"]
+signals = ["blinker (>=1.4.0)"]
+signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
+
+[[package]]
 name = "orderly-set"
 version = "5.4.1"
 description = "Orderly set"
@@ -2353,6 +2370,23 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pyoncat"
+version = "2.1"
+description = "A Python Client for ONCat (the ORNL Neutron Catalog)."
+optional = false
+python-versions = "<4,>=3.7"
+groups = ["main"]
+files = [
+    {file = "pyoncat-2.1-py3-none-any.whl", hash = "sha256:4bf742fca50ac5e10564c76fd226d50bb06a408e17e320fd4fb9e38cc98c0a28"},
+    {file = "pyoncat-2.1.tar.gz", hash = "sha256:4b7ad0792833269aed5207ec42b7898a3e0b74860c69d0be585335b31982da72"},
+]
+
+[package.dependencies]
+oauthlib = "*"
+requests = "*"
+requests-oauthlib = "*"
+
+[[package]]
 name = "pyparsing"
 version = "3.2.3"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
@@ -2517,7 +2551,7 @@ version = "2.32.4"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c"},
     {file = "requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422"},
@@ -2532,6 +2566,25 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+description = "OAuthlib authentication support for Requests."
+optional = false
+python-versions = ">=3.4"
+groups = ["main"]
+files = [
+    {file = "requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"},
+    {file = "requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36"},
+]
+
+[package.dependencies]
+oauthlib = ">=3.0.0"
+requests = ">=2.0.0"
+
+[package.extras]
+rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
 name = "roman-numerals-py"
@@ -3317,7 +3370,7 @@ version = "2.4.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
     {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
@@ -3541,4 +3594,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "9d3890dfa9395634fbc22e7361e5be295dc8ac4b30fd1a202b63a228a11bc184"
+content-hash = "9358742de336110b5e1ab489157b088429f40332e86fbf6f51174f263bf00fa3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nova-trame"
-version = "0.24.0"
+version = "0.25.0"
 description = "A Python Package for injecting curated themes and custom components into Trame applications"
 authors = [
     { name = "John Duggan", email = "dugganjw@ornl.gov" },
@@ -36,6 +36,7 @@ pydantic = "*"
 nova-common = ">=0.2.2"
 blinker = "^1.9.0"
 natsort = "^8.4.0"
+pyoncat = "^2.1"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.10.0"

--- a/src/nova/trame/model/ornl/analysis_data_selector.py
+++ b/src/nova/trame/model/ornl/analysis_data_selector.py
@@ -1,0 +1,162 @@
+"""Analysis cluster filesystem backend for NeutronDataSelector."""
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from warnings import warn
+
+from natsort import natsorted
+from pydantic import Field, model_validator
+from typing_extensions import Self
+
+from .neutron_data_selector import NeutronDataSelectorModel, NeutronDataSelectorState
+
+CUSTOM_DIRECTORIES_LABEL = "Custom Directory"
+
+INSTRUMENTS = {
+    "HFIR": {
+        "CG-1A": "CG1A",
+        "DEV BEAM": "CG1B",
+        "MARS": "CG1D",
+        "GP-SANS": "CG2",
+        "BIO-SANS": "CG3",
+        "CNPDB": "CG4B",
+        "CTAX": "CG4C",
+        "IMAGINE": "CG4D",
+        "PTAX": "HB1",
+        "VERITAS": "HB1A",
+        "POWDER": "HB2A",
+        "HIDRA": "HB2B",
+        "WAND²": "HB2C",
+        "TAX": "HB3",
+        "DEMAND": "HB3A",
+        "NOWG": "NOWG",
+        "NOWV": "NOWV",
+    },
+    "SNS": {
+        "ARCS": "ARCS",
+        "BL-0": "BL0",
+        "BASIS": "BSS",
+        "CNCS": "CNCS",
+        "CORELLI": "CORELLI",
+        "EQ-SANS": "EQSANS",
+        "HYSPEC": "HYS",
+        "MANDI": "MANDI",
+        "NOMAD": "NOM",
+        "NOWB": "NOWB",
+        "NOWD": "NOWD",
+        "NSE": "NSE",
+        "POWGEN": "PG3",
+        "LIQREF": "REF_L",
+        "MAGREF": "REF_M",
+        "SEQUOIA": "SEQ",
+        "SNAP": "SNAP",
+        "TOPAZ": "TOPAZ",
+        "USANS": "USANS",
+        "VENUS": "VENUS",
+        "VISION": "VIS",
+        "VULCAN": "VULCAN",
+    },
+}
+
+
+class AnalysisDataSelectorState(NeutronDataSelectorState):
+    """Selection state for identifying datafiles."""
+
+    allow_custom_directories: bool = Field(default=False)
+    custom_directory: str = Field(default="", title="Custom Directory")
+
+    @model_validator(mode="after")
+    def validate_state(self) -> Self:
+        valid_facilities = self.get_facilities()
+        if self.facility and self.facility not in valid_facilities:
+            warn(f"Facility '{self.facility}' could not be found. Valid options: {valid_facilities}", stacklevel=1)
+
+        valid_instruments = self.get_instruments()
+        if self.instrument and self.facility != CUSTOM_DIRECTORIES_LABEL and self.instrument not in valid_instruments:
+            warn(
+                (
+                    f"Instrument '{self.instrument}' could not be found in '{self.facility}'. "
+                    f"Valid options: {valid_instruments}"
+                ),
+                stacklevel=1,
+            )
+        # Validating the experiment is expensive and will fail in our CI due to the filesystem not being mounted there.
+
+        return self
+
+    def get_facilities(self) -> List[str]:
+        facilities = list(INSTRUMENTS.keys())
+        if self.allow_custom_directories:
+            facilities.append(CUSTOM_DIRECTORIES_LABEL)
+        return facilities
+
+    def get_instruments(self) -> List[str]:
+        return list(INSTRUMENTS.get(self.facility, {}).keys())
+
+
+class AnalysisDataSelectorModel(NeutronDataSelectorModel):
+    """Analysis cluster filesystem backend for NeutronDataSelector."""
+
+    def __init__(self, state: AnalysisDataSelectorState) -> None:
+        super().__init__(state)
+        self.state: AnalysisDataSelectorState = state
+
+    def set_binding_parameters(self, **kwargs: Any) -> None:
+        super().set_binding_parameters(**kwargs)
+
+        if "allow_custom_directories" in kwargs:
+            self.state.allow_custom_directories = kwargs["allow_custom_directories"]
+
+    def get_custom_directory_path(self) -> Optional[Path]:
+        # Don't expose the full file system
+        if not self.state.custom_directory:
+            return None
+
+        return Path(self.state.custom_directory)
+
+    def get_experiment_directory_path(self) -> Optional[Path]:
+        if not self.state.experiment:
+            return None
+
+        return Path("/") / self.state.facility / self.get_instrument_dir() / self.state.experiment
+
+    def get_instrument_dir(self) -> str:
+        return INSTRUMENTS.get(self.state.facility, {}).get(self.state.instrument, "")
+
+    def get_experiments(self) -> List[str]:
+        experiments = []
+
+        instrument_path = Path("/") / self.state.facility / self.get_instrument_dir()
+        try:
+            for dirname in os.listdir(instrument_path):
+                if dirname.startswith("IPTS-") and os.access(instrument_path / dirname, mode=os.R_OK):
+                    experiments.append(dirname)
+        except OSError:
+            pass
+
+        return natsorted(experiments)
+
+    def get_directories(self, base_path: Optional[Path] = None) -> List[Dict[str, Any]]:
+        using_custom_directory = self.state.facility == CUSTOM_DIRECTORIES_LABEL
+        if base_path:
+            pass
+        elif using_custom_directory:
+            base_path = self.get_custom_directory_path()
+        else:
+            base_path = self.get_experiment_directory_path()
+
+        if not base_path:
+            return []
+
+        return self.get_directories_from_path(base_path)
+
+    def get_datafiles(self, *args: Any, **kwargs: Any) -> List[str]:
+        if self.state.experiment:
+            base_path = Path("/") / self.state.facility / self.get_instrument_dir() / self.state.experiment
+        elif self.state.custom_directory:
+            base_path = Path(self.state.custom_directory)
+        else:
+            return []
+
+        return self.get_datafiles_from_path(base_path)

--- a/src/nova/trame/model/ornl/analysis_data_selector.py
+++ b/src/nova/trame/model/ornl/analysis_data_selector.py
@@ -154,7 +154,7 @@ class AnalysisDataSelectorModel(NeutronDataSelectorModel):
 
         return self.get_directories_from_path(base_path)
 
-    def get_datafiles(self, *args: Any, **kwargs: Any) -> List[str]:
+    def get_datafiles(self, *args: Any, **kwargs: Any) -> List[Any]:
         using_custom_directory = self.state.facility == CUSTOM_DIRECTORIES_LABEL
         if self.state.experiment:
             base_path = Path("/") / self.state.facility / self.get_instrument_dir() / self.state.experiment
@@ -163,4 +163,4 @@ class AnalysisDataSelectorModel(NeutronDataSelectorModel):
         else:
             return []
 
-        return self.get_datafiles_from_path(base_path)
+        return [{"path": path} for path in self.get_datafiles_from_path(base_path)]

--- a/src/nova/trame/model/ornl/neutron_data_selector.py
+++ b/src/nova/trame/model/ornl/neutron_data_selector.py
@@ -1,72 +1,20 @@
 """Model implementation for DataSelector."""
 
-import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-from warnings import warn
 
 from natsort import natsorted
-from pydantic import Field, field_validator, model_validator
-from typing_extensions import Self
+from pydantic import Field, field_validator
 
 from ..data_selector import DataSelectorModel, DataSelectorState
-
-CUSTOM_DIRECTORIES_LABEL = "Custom Directory"
-
-INSTRUMENTS = {
-    "HFIR": {
-        "CG-1A": "CG1A",
-        "CG-1B": "CG1B",
-        "CG-1D": "CG1D",
-        "CG-2": "CG2",
-        "CG-3": "CG3",
-        "CG-4B": "CG4B",
-        "CG-4C": "CG4C",
-        "CG-4D": "CG4D",
-        "HB-1": "HB1",
-        "HB-1A": "HB1A",
-        "HB-2A": "HB2A",
-        "HB-2B": "HB2B",
-        "HB-2C": "HB2C",
-        "HB-3": "HB3",
-        "HB-3A": "HB3A",
-        "NOW-G": "NOWG",
-        "NOW-V": "NOWV",
-    },
-    "SNS": {
-        "BL-18": "ARCS",
-        "BL-0": "BL0",
-        "BL-2": "BSS",
-        "BL-5": "CNCS",
-        "BL-9": "CORELLI",
-        "BL-6": "EQSANS",
-        "BL-14B": "HYS",
-        "BL-11B": "MANDI",
-        "BL-1B": "NOM",
-        "NOW-G": "NOWG",
-        "BL-15": "NSE",
-        "BL-11A": "PG3",
-        "BL-4B": "REF_L",
-        "BL-4A": "REF_M",
-        "BL-17": "SEQ",
-        "BL-3": "SNAP",
-        "BL-12": "TOPAZ",
-        "BL-1A": "USANS",
-        "BL-10": "VENUS",
-        "BL-16B": "VIS",
-        "BL-7": "VULCAN",
-    },
-}
 
 
 class NeutronDataSelectorState(DataSelectorState):
     """Selection state for identifying datafiles."""
 
-    allow_custom_directories: bool = Field(default=False)
     facility: str = Field(default="", title="Facility")
     instrument: str = Field(default="", title="Instrument")
     experiment: str = Field(default="", title="Experiment")
-    custom_directory: str = Field(default="", title="Custom Directory")
 
     @field_validator("experiment", mode="after")
     @classmethod
@@ -75,33 +23,11 @@ class NeutronDataSelectorState(DataSelectorState):
             raise ValueError("experiment must begin with IPTS-")
         return experiment
 
-    @model_validator(mode="after")
-    def validate_state(self) -> Self:
-        valid_facilities = self.get_facilities()
-        if self.facility and self.facility not in valid_facilities:
-            warn(f"Facility '{self.facility}' could not be found. Valid options: {valid_facilities}", stacklevel=1)
-
-        valid_instruments = self.get_instruments()
-        if self.instrument and self.facility != CUSTOM_DIRECTORIES_LABEL and self.instrument not in valid_instruments:
-            warn(
-                (
-                    f"Instrument '{self.instrument}' could not be found in '{self.facility}'. "
-                    f"Valid options: {valid_instruments}"
-                ),
-                stacklevel=1,
-            )
-        # Validating the experiment is expensive and will fail in our CI due to the filesystem not being mounted there.
-
-        return self
-
     def get_facilities(self) -> List[str]:
-        facilities = list(INSTRUMENTS.keys())
-        if self.allow_custom_directories:
-            facilities.append(CUSTOM_DIRECTORIES_LABEL)
-        return facilities
+        raise NotImplementedError()
 
     def get_instruments(self) -> List[str]:
-        return list(INSTRUMENTS.get(self.facility, {}).keys())
+        raise NotImplementedError()
 
 
 class NeutronDataSelectorModel(DataSelectorModel):
@@ -120,64 +46,18 @@ class NeutronDataSelectorModel(DataSelectorModel):
             self.state.instrument = kwargs["instrument"]
         if "experiment" in kwargs:
             self.state.experiment = kwargs["experiment"]
-        if "allow_custom_directories" in kwargs:
-            self.state.allow_custom_directories = kwargs["allow_custom_directories"]
 
     def get_facilities(self) -> List[str]:
         return natsorted(self.state.get_facilities())
-
-    def get_instrument_dir(self) -> str:
-        return INSTRUMENTS.get(self.state.facility, {}).get(self.state.instrument, "")
 
     def get_instruments(self) -> List[str]:
         return natsorted(self.state.get_instruments())
 
     def get_experiments(self) -> List[str]:
-        experiments = []
-
-        instrument_path = Path("/") / self.state.facility / self.get_instrument_dir()
-        try:
-            for dirname in os.listdir(instrument_path):
-                if dirname.startswith("IPTS-") and os.access(instrument_path / dirname, mode=os.R_OK):
-                    experiments.append(dirname)
-        except OSError:
-            pass
-
-        return natsorted(experiments)
-
-    def get_experiment_directory_path(self) -> Optional[Path]:
-        if not self.state.experiment:
-            return None
-
-        return Path("/") / self.state.facility / self.get_instrument_dir() / self.state.experiment
-
-    def get_custom_directory_path(self) -> Optional[Path]:
-        # Don't expose the full file system
-        if not self.state.custom_directory:
-            return None
-
-        return Path(self.state.custom_directory)
+        raise NotImplementedError()
 
     def get_directories(self, base_path: Optional[Path] = None) -> List[Dict[str, Any]]:
-        using_custom_directory = self.state.facility == CUSTOM_DIRECTORIES_LABEL
-        if base_path:
-            pass
-        elif using_custom_directory:
-            base_path = self.get_custom_directory_path()
-        else:
-            base_path = self.get_experiment_directory_path()
+        raise NotImplementedError()
 
-        if not base_path:
-            return []
-
-        return self.get_directories_from_path(base_path)
-
-    def get_datafiles(self) -> List[str]:
-        if self.state.experiment:
-            base_path = Path("/") / self.state.facility / self.get_instrument_dir() / self.state.experiment
-        elif self.state.custom_directory:
-            base_path = Path(self.state.custom_directory)
-        else:
-            return []
-
-        return self.get_datafiles_from_path(base_path)
+    def get_datafiles(self, *args: Any, **kwargs: Any) -> List[str]:
+        raise NotImplementedError()

--- a/src/nova/trame/model/ornl/oncat_data_selector.py
+++ b/src/nova/trame/model/ornl/oncat_data_selector.py
@@ -1,0 +1,131 @@
+"""ONCat backend for NeutronDataSelector."""
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from natsort import natsorted
+from pydantic import Field
+from pyoncat import CLIENT_CREDENTIALS_FLOW, ONCat
+
+from .neutron_data_selector import NeutronDataSelectorModel, NeutronDataSelectorState
+
+TOKEN_VARNAME = "USER_OIDC_TOKEN"
+ID_VARNAME = "ONCAT_CLIENT_ID"
+SECRET_VARNAME = "ONCAT_CLIENT_SECRET"
+
+
+class ONCatDataSelectorState(NeutronDataSelectorState):
+    """Selection state for identifying datafiles."""
+
+    instrument_mapping: Dict[str, str] = Field(default={})
+    projection: List[str] = Field(default=[])
+
+
+class ONCatDataSelectorModel(NeutronDataSelectorModel):
+    """ONCat backend for NeutronDataSelector."""
+
+    def __init__(self, state: ONCatDataSelectorState) -> None:
+        super().__init__(state)
+        self.state: ONCatDataSelectorState = state
+
+        user_token = os.environ.get(TOKEN_VARNAME, "")
+        client_id = os.environ.get(ID_VARNAME, "")
+        client_secret = os.environ.get(SECRET_VARNAME, "")
+        if user_token:
+            self.oncat_client = ONCat(url="https://calvera-test.ornl.gov/oncat", api_token=user_token)
+        elif client_id and client_secret:
+            self.oncat_client = ONCat(
+                url="https://oncat.ornl.gov",
+                client_id=client_id,
+                client_secret=client_secret,
+                flow=CLIENT_CREDENTIALS_FLOW,
+            )
+        else:
+            raise EnvironmentError(
+                f"In order to use the ONCat backend for NeutronDataSelector, you must set either {TOKEN_VARNAME} or "
+                f"both {ID_VARNAME} and {SECRET_VARNAME} in your environment."
+            )
+
+    def set_binding_parameters(self, **kwargs: Any) -> None:
+        super().set_binding_parameters(**kwargs)
+
+        if "projection" in kwargs:
+            self.state.projection = kwargs["projection"]
+
+    def get_facilities(self) -> List[str]:
+        facilities = []
+        for facility_data in self.oncat_client.Facility.list(projection=["name"]):
+            facilities.append(facility_data.name)
+        return natsorted(facilities)
+
+    def get_instruments(self) -> List[str]:
+        if not self.state.facility:
+            return []
+
+        self.state.instrument_mapping = {}
+        instruments = []
+        for instrument_data in self.oncat_client.Instrument.list(
+            facility=self.state.facility, projection=["short_name"]
+        ):
+            self.state.instrument_mapping[instrument_data.short_name] = instrument_data.id
+            instruments.append(instrument_data.short_name)
+        return natsorted(instruments)
+
+    def get_experiments(self) -> List[str]:
+        if not self.state.facility or not self.state.instrument:
+            return []
+
+        experiments = []
+        for experiment_data in self.oncat_client.Experiment.list(
+            facility=self.state.facility,
+            instrument=self.state.instrument_mapping[self.state.instrument],
+            projection=["name"],
+        ):
+            experiments.append(experiment_data.name)
+        return natsorted(experiments)
+
+    def get_directories(self, _: Optional[Path] = None) -> List[Dict[str, Any]]:
+        return []
+
+    def create_datafile_obj(self, data: Dict[str, Any], projection: List[str]) -> Dict[str, str]:
+        new_obj = {"path": data["location"]}
+
+        for key in projection:
+            value: Any = data
+
+            if key == "location":
+                continue
+
+            for part in key.split("."):
+                try:
+                    value = value[part]
+                except KeyError:
+                    value = ""
+                    break
+
+            new_obj[key] = value
+
+        return new_obj
+
+    def get_datafiles(self, *args: Any, **kwargs: Any) -> List[Any]:
+        if not self.state.facility or not self.state.instrument or not self.state.experiment:
+            return []
+
+        projection = ["location"] + self.state.projection
+
+        datafiles = []
+        for datafile_data in self.oncat_client.Datafile.list(
+            facility=self.state.facility,
+            instrument=self.state.instrument_mapping[self.state.instrument],
+            experiment=self.state.experiment,
+            projection=projection,
+        ):
+            path = datafile_data.location
+            if self.state.extensions:
+                for extension in self.state.extensions:
+                    if path.lower().endswith(extension):
+                        datafiles.append(self.create_datafile_obj(datafile_data, projection))
+            else:
+                datafiles.append(self.create_datafile_obj(datafile_data, projection))
+        return natsorted(datafiles, key=lambda d: d["path"])

--- a/src/nova/trame/view/components/data_selector.py
+++ b/src/nova/trame/view/components/data_selector.py
@@ -155,10 +155,10 @@ class DataSelector(datagrid.VGrid):
                         )
                         vuetify.VListItem("No directories found", classes="flex-0-1 text-center", v_else=True)
 
-                super().__init__(
-                    v_model=self._v_model,
-                    can_focus=False,
-                    columns=(
+                if "columns" in kwargs:
+                    columns = kwargs.pop("columns")
+                else:
+                    columns = (
                         "[{"
                         "    cellTemplate: (createElement, props) =>"
                         f"       window.grid_manager.get('{self._revogrid_id}').cellTemplate(createElement, props),"
@@ -167,7 +167,12 @@ class DataSelector(datagrid.VGrid):
                         "    name: 'Available Datafiles',"
                         "    prop: 'title',"
                         "}]",
-                    ),
+                    )
+
+                super().__init__(
+                    v_model=self._v_model,
+                    can_focus=False,
+                    columns=columns,
                     column_span=1 if isinstance(self._subdirectory, tuple) or not self._subdirectory else 2,
                     frame_size=10,
                     hide_attribution=True,

--- a/src/nova/trame/view/components/ornl/neutron_data_selector.py
+++ b/src/nova/trame/view/components/ornl/neutron_data_selector.py
@@ -1,6 +1,6 @@
 """View Implementation for DataSelector."""
 
-from typing import Any, List, Tuple, Union
+from typing import Any, List, Literal, Tuple, Union
 from warnings import warn
 
 from trame.app import get_server
@@ -8,11 +8,13 @@ from trame.widgets import vuetify3 as vuetify
 
 from nova.mvvm._internal.utils import rgetdictvalue
 from nova.mvvm.trame_binding import TrameBinding
-from nova.trame.model.ornl.neutron_data_selector import (
+from nova.trame.model.ornl.analysis_data_selector import (
     CUSTOM_DIRECTORIES_LABEL,
-    NeutronDataSelectorModel,
-    NeutronDataSelectorState,
+    AnalysisDataSelectorModel,
+    AnalysisDataSelectorState,
 )
+from nova.trame.model.ornl.neutron_data_selector import NeutronDataSelectorModel
+from nova.trame.model.ornl.oncat_data_selector import ONCatDataSelectorModel, ONCatDataSelectorState
 from nova.trame.view.layouts import GridLayout
 from nova.trame.view_model.ornl.neutron_data_selector import NeutronDataSelectorViewModel
 
@@ -29,10 +31,12 @@ class NeutronDataSelector(DataSelector):
         self,
         v_model: Union[str, Tuple],
         allow_custom_directories: Union[bool, Tuple] = False,
+        data_source: Literal["filesystem", "oncat"] = "filesystem",
         facility: Union[str, Tuple] = "",
         instrument: Union[str, Tuple] = "",
         experiment: Union[str, Tuple] = "",
         extensions: Union[List[str], Tuple, None] = None,
+        projection: Union[List[str], Tuple, None] = None,
         subdirectory: Union[str, Tuple] = "",
         refresh_rate: Union[int, Tuple] = 30,
         select_strategy: Union[str, Tuple] = "all",
@@ -48,6 +52,11 @@ class NeutronDataSelector(DataSelector):
         allow_custom_directories : Union[bool, Tuple], optional
             Whether or not to allow users to provide their own directories to search for datafiles in. Ignored if the
             facility parameter is set.
+        data_source : Literal["filesystem", "oncat"], optional
+            The source from which to pull datafiles. Defaults to "filesystem". If using ONCat, you will need to set the
+            following environment variables for local development: `ONCAT_CLIENT_ID` and `ONCAT_CLIENT_SECRET`. Note
+            that this parameter does not supporting Trame bindings. If you need to swap between the options, please
+            create two instances of this class and switch between them using a v_if or a v_show.
         facility : Union[str, Tuple], optional
             The facility to restrict data selection to. Options: HFIR, SNS
         instrument : Union[str, Tuple], optional
@@ -56,6 +65,9 @@ class NeutronDataSelector(DataSelector):
             The experiment to restrict data selection to.
         extensions : Union[List[str], Tuple], optional
             A list of file extensions to restrict selection to. If unset, then all files will be shown.
+        projection : Union[List[str], Tuple], optional
+            Sets the projection argument when pulling data files via pyoncat. Please refer to the ONCat documentation
+            for how to use this. This should only be used with `data_source="oncat"`.
         subdirectory : Union[str, Tuple], optional
             A subdirectory within the user's chosen experiment to show files. If not specified as a string, the user
             will be shown a folder browser and will be able to see all files in the experiment that they have access to.
@@ -73,6 +85,12 @@ class NeutronDataSelector(DataSelector):
         -------
         None
         """
+        if data_source == "oncat" and allow_custom_directories:
+            warn("allow_custom_directories will be ignored since data will be pulled from ONCat.", stacklevel=1)
+
+        if data_source == "oncat" and subdirectory:
+            warn("subdirectory will be ignored since data will be pulled from ONCat.", stacklevel=1)
+
         if isinstance(facility, str) and allow_custom_directories:
             warn("allow_custom_directories will be ignored since the facility parameter is fixed.", stacklevel=1)
 
@@ -81,6 +99,8 @@ class NeutronDataSelector(DataSelector):
         self._experiment = experiment
         self._allow_custom_directories = allow_custom_directories
         self._last_allow_custom_directories = self._allow_custom_directories
+        self._data_source = data_source
+        self._projection = projection
 
         self._state_name = f"nova__dataselector_{self._next_id}_state"
         self._facilities_name = f"nova__neutrondataselector_{self._next_id}_facilities"
@@ -100,19 +120,43 @@ class NeutronDataSelector(DataSelector):
             v_model,
             "",
             extensions=extensions,
-            subdirectory=subdirectory,
+            subdirectory=subdirectory if data_source == "filesystem" else "oncat",
             refresh_rate=refresh_rate,
             select_strategy=select_strategy,
             **kwargs,
         )
 
+    def create_projection_column_title(self, key: str) -> str:
+        return key.split(".")[-1].replace("_", " ").title()
+
     def create_ui(self, **kwargs: Any) -> None:
-        super().create_ui(**kwargs)
+        if self._data_source == "oncat":
+            columns = (
+                "["
+                "  {"
+                "    cellTemplate: (createElement, props) =>"
+                f"     window.grid_manager.get('{self._revogrid_id}').cellTemplate(createElement, props),"
+                "    columnTemplate: (createElement) =>"
+                f"     window.grid_manager.get('{self._revogrid_id}').columnTemplate(createElement),"
+                "    name: 'Available Datafiles',"
+                "    prop: 'title',"
+                "    size: 150,"
+                "  },"
+            )
+            if self._projection:
+                for key in self._projection:
+                    columns += f"{{name: '{self.create_projection_column_title(key)}', prop: '{key}', size: 150}},"
+            columns += "]"
+
+            super().create_ui(columns=(columns,), resize=True, **kwargs)
+        else:
+            super().create_ui(**kwargs)
+
         with self._layout.filter:
             with GridLayout(columns=3):
-                columns = 3
+                column_span = 3
                 if isinstance(self._facility, tuple) or not self._facility:
-                    columns -= 1
+                    column_span -= 1
                     InputField(
                         v_model=self._selected_facility_name,
                         items=(self._facilities_name,),
@@ -120,7 +164,7 @@ class NeutronDataSelector(DataSelector):
                         update_modelValue=(self.update_facility, "[$event]"),
                     )
                 if isinstance(self._instrument, tuple) or not self._instrument:
-                    columns -= 1
+                    column_span -= 1
                     InputField(
                         v_if=f"{self._selected_facility_name} !== '{CUSTOM_DIRECTORIES_LABEL}'",
                         v_model=self._selected_instrument_name,
@@ -131,7 +175,7 @@ class NeutronDataSelector(DataSelector):
                 InputField(
                     v_if=f"{self._selected_facility_name} !== '{CUSTOM_DIRECTORIES_LABEL}'",
                     v_model=self._selected_experiment_name,
-                    column_span=columns,
+                    column_span=column_span,
                     items=(self._experiments_name,),
                     type="autocomplete",
                     update_modelValue=(self.update_experiment, "[$event]"),
@@ -139,8 +183,11 @@ class NeutronDataSelector(DataSelector):
                 InputField(v_else=True, v_model=f"{self._state_name}.custom_directory", column_span=2)
 
     def _create_model(self) -> None:
-        state = NeutronDataSelectorState()
-        self._model: NeutronDataSelectorModel = NeutronDataSelectorModel(state)
+        self._model: NeutronDataSelectorModel
+        if self._data_source == "oncat":
+            self._model = ONCatDataSelectorModel(ONCatDataSelectorState())
+        else:
+            self._model = AnalysisDataSelectorModel(AnalysisDataSelectorState())
 
     def _create_viewmodel(self) -> None:
         server = get_server(None, client_type="vue3")
@@ -166,6 +213,7 @@ class NeutronDataSelector(DataSelector):
         set_state_param(self.state, self._instrument)
         set_state_param(self.state, self._experiment)
         set_state_param(self.state, self._allow_custom_directories)
+        set_state_param(self.state, self._projection)
         self._last_facility = get_state_param(self.state, self._facility)
         self._last_instrument = get_state_param(self.state, self._instrument)
         self._last_experiment = get_state_param(self.state, self._experiment)
@@ -174,6 +222,7 @@ class NeutronDataSelector(DataSelector):
             instrument=get_state_param(self.state, self._instrument),
             experiment=get_state_param(self.state, self._experiment),
             allow_custom_directories=get_state_param(self.state, self._allow_custom_directories),
+            projection=get_state_param(self.state, self._projection),
         )
 
         # Now we set up the change listeners for all bound parameters. These are responsible for updating the component
@@ -225,6 +274,17 @@ class NeutronDataSelector(DataSelector):
                         allow_custom_directories=set_state_param(
                             self.state, self._allow_custom_directories, allow_custom_directories
                         )
+                    )
+
+        if isinstance(self._projection, tuple):
+
+            @self.state.change(self._projection[0].split(".")[0])
+            def on_projection_change(**kwargs: Any) -> None:
+                projection = rgetdictvalue(kwargs, self._projection[0])  # type: ignore
+                if projection != self._projection:
+                    self._projection = projection
+                    self._vm.set_binding_parameters(
+                        projection=set_state_param(self.state, self._projection, projection)
                     )
 
     # These update methods notify the rest of the application when the component changes bound parameters.

--- a/src/nova/trame/view/theme/assets/js/revo_grid.js
+++ b/src/nova/trame/view/theme/assets/js/revo_grid.js
@@ -21,7 +21,7 @@ class RevoGrid {
         const modelValue = _.get(trameState, this.modelKey)
         const availableData = _.get(trameState, this.dataKey)
         const selectAllCheckbox = this.grid.querySelector(".header-content input")
-        const rowCheckboxes = this.grid.querySelectorAll(".rgCell")
+        const rowCheckboxes = this.grid.querySelectorAll(".rgCell:first-child")
 
         if (selectAllCheckbox === null) {
             return

--- a/src/nova/trame/view_model/data_selector.py
+++ b/src/nova/trame/view_model/data_selector.py
@@ -65,6 +65,9 @@ class DataSelectorViewModel:
         self.model.set_subdirectory(subdirectory_path)
         self.update_view()
 
+    def transform_datafiles(self, datafiles: List[Any]) -> List[Dict[str, str]]:
+        return [{"path": datafile, "title": os.path.basename(datafile)} for datafile in datafiles]
+
     def update_view(self, refresh_directories: bool = False) -> None:
         self.state_bind.update_in_view(self.model.state)
         if not self.directories or refresh_directories:
@@ -72,7 +75,5 @@ class DataSelectorViewModel:
             self.reexpand_directories()
         self.directories_bind.update_in_view(self.directories)
 
-        self.datafiles = [
-            {"path": datafile, "title": os.path.basename(datafile)} for datafile in self.model.get_datafiles()
-        ]
+        self.datafiles = self.transform_datafiles(self.model.get_datafiles())
         self.datafiles_bind.update_in_view(self.datafiles)

--- a/src/nova/trame/view_model/ornl/neutron_data_selector.py
+++ b/src/nova/trame/view_model/ornl/neutron_data_selector.py
@@ -1,6 +1,7 @@
 """View model implementation for the DataSelector widget."""
 
-from typing import Any, Dict
+import os
+from typing import Any, Dict, List
 
 from nova.mvvm.interface import BindingInterface
 from nova.trame.model.ornl.neutron_data_selector import NeutronDataSelectorModel
@@ -30,6 +31,9 @@ class NeutronDataSelectorViewModel(DataSelectorViewModel):
                 case "custom_directory":
                     self.reset()
                     self.update_view()
+
+    def transform_datafiles(self, datafiles: List[Any]) -> List[Dict[str, str]]:
+        return [{"title": os.path.basename(datafile["path"]), **datafile} for datafile in datafiles]
 
     def update_view(self, refresh_directories: bool = False) -> None:
         self.facilities_bind.update_in_view(self.model.get_facilities())

--- a/tests/gallery/models/neutron_data_selector.py
+++ b/tests/gallery/models/neutron_data_selector.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 
 
 class NeutronDataSelectorBindingTest(BaseModel):
-    """Model for testing binding parameters for DataSelector."""
+    """Model for testing binding parameters for NeutronDataSelector."""
 
     facility: str = Field(default="", title="Facility")
     instrument: str = Field(default="", title="Instrument")
@@ -14,7 +14,13 @@ class NeutronDataSelectorBindingTest(BaseModel):
     allow_custom_directories: bool = Field(default=False, title="Allow Custom Directories?")
 
 
-class NeutronDataSelectorState(BaseModel):
-    """Model for MVVM demo of DataSelector."""
+class AnalysisDataSelectorState(BaseModel):
+    """Model for MVVM demo of NeutronDataSelector."""
+
+    selected_files: List[str] = Field(default=[], title="Selected Files")
+
+
+class ONCatDataSelectorState(BaseModel):
+    """Model for MVVM demo of NeutronDataSelector."""
 
     selected_files: List[str] = Field(default=[], title="Selected Files")

--- a/tests/gallery/view_models/neutron_data_selector.py
+++ b/tests/gallery/view_models/neutron_data_selector.py
@@ -3,21 +3,27 @@
 from typing import Any, Dict
 
 from nova.mvvm.interface import BindingInterface
-from tests.gallery.models.neutron_data_selector import NeutronDataSelectorBindingTest, NeutronDataSelectorState
+from tests.gallery.models.neutron_data_selector import (
+    AnalysisDataSelectorState,
+    NeutronDataSelectorBindingTest,
+    ONCatDataSelectorState,
+)
 
 
 class NeutronDataSelectorVM:
     """View model for MVVM demo of NeutronDataSelector."""
 
     def __init__(self, binding: BindingInterface) -> None:
-        self.model = NeutronDataSelectorState()
+        self.analysis_model = AnalysisDataSelectorState()
+        self.oncat_model = ONCatDataSelectorState()
         self.binding_test = NeutronDataSelectorBindingTest()
 
-        self.model_bind = binding.new_bind(self.model, callback_after_update=self.on_update)
+        self.analysis_bind = binding.new_bind(self.analysis_model, callback_after_update=self.on_update)
+        self.oncat_bind = binding.new_bind(self.oncat_model)
         self.parameter_bind = binding.new_bind(self.binding_test, callback_after_update=self.on_parameter_update)
 
     def on_update(self, data: Dict[str, Any]) -> None:
-        print(data, self.model)
+        print(data, self.analysis_model)
 
     def on_parameter_update(self, data: Dict[str, Any]) -> None:
         print(data, self.binding_test)

--- a/tests/gallery/views/app.py
+++ b/tests/gallery/views/app.py
@@ -166,7 +166,8 @@ class App(ThemedApp):
         self.data_selector_vm.parameter_bind.connect("ds_params")
 
         self.neutron_data_selector_vm = NeutronDataSelectorVM(binding)
-        self.neutron_data_selector_vm.model_bind.connect("neutron_data_selector")
+        self.neutron_data_selector_vm.analysis_bind.connect("nds_filesystem")
+        self.neutron_data_selector_vm.oncat_bind.connect("nds_oncat")
         self.neutron_data_selector_vm.parameter_bind.connect("nds_params")
 
         self.file_upload_vm = FileUploadVM(binding)
@@ -373,13 +374,27 @@ class App(ThemedApp):
                         InputField(v_model="nds_params.allow_custom_directories", type="checkbox")
                     with html.Div(classes="border-md text-left", style="height: 650px; width: 600px;"):
                         NeutronDataSelector(
-                            v_model="neutron_data_selector.selected_files",
+                            v_model="nds_filesystem.selected_files",
                             facility=("nds_params.facility", "SNS"),
-                            instrument=("nds_params.instrument", "BL-12"),
+                            instrument=("nds_params.instrument", "TOPAZ"),
                             experiment=("nds_params.experiment", "IPTS-12132"),
                             allow_custom_directories=("nds_params.allow_custom_directories", True),
                             chips=True,
                         )
+                    with html.Div(classes="border-md text-left", style="height: 650px; width: 600px;"):
+                        try:
+                            NeutronDataSelector(
+                                v_model="nds_oncat.selected_files",
+                                data_source="oncat",
+                                projection=["indexed.run_number", "metadata.entry.title"],
+                                chips=True,
+                            )
+                        except EnvironmentError:
+                            # Unit tests will fail without this in the CI since ONCat vars won't be defined.
+                            html.Span(
+                                "You must define ONCAT_CLIENT_ID and ONCAT_CLIENT_SECRET in your environment in order "
+                                "to test the ONCat backend for NeutronDataSelector."
+                            )
 
                     vuetify.VCardTitle("Form Inputs & Controls")
                     with GridLayout(columns=3, valign="center"):

--- a/tests/test_neutron_data_selector.py
+++ b/tests/test_neutron_data_selector.py
@@ -79,7 +79,7 @@ def test_parameter_bindings() -> None:
                     NeutronDataSelector(
                         v_model=("test_nds.v_model", ["test.txt"]),
                         facility=("test_nds.facility", "SNS"),
-                        instrument=("test_nds.instrument", "BL-12"),
+                        instrument=("test_nds.instrument", "TOPAZ"),
                         experiment=("test_nds.experiment",),
                         allow_custom_directories=("test_nds.allow_custom_directories", True),
                     )


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
This adds two new parameters to NeutronDataSelector:

1. data_source - Allows the dev to set whether data is pulled from the analysis cluster or ONCat.
2. projection - Shows additional fields from ONCat in the data table (matches pyoncat parameter). Ignored if using the analysis cluster.

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [x] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
