### PR TITLE
Add return_contents parameter to match RemoteFileInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### nova-trame, 0.25.0
+
+* FileUpload now supports a return_contents parameter (thanks to John Duggan).
+
 ### nova-trame, 0.24.1
 
 * Fixed literalinclude paths in the documentation (thanks to John Duggan).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nova-trame"
-version = "0.24.1"
+version = "0.25.0"
 description = "A Python Package for injecting curated themes and custom components into Trame applications"
 authors = [
     { name = "John Duggan", email = "dugganjw@ornl.gov" },

--- a/src/nova/trame/view/components/remote_file_input.py
+++ b/src/nova/trame/view/components/remote_file_input.py
@@ -1,6 +1,7 @@
 """View implementation for RemoteFileInput."""
 
 from functools import partial
+from tempfile import NamedTemporaryFile
 from typing import Any, Optional, Union, cast
 
 from trame.app import get_server
@@ -207,9 +208,15 @@ class RemoteFileInput:
         with open(file_path, mode="rb") as file:
             self.decode_file(file.read())
 
-    def decode_file(self, bytestream: bytes) -> None:
+    def decode_file(self, bytestream: bytes, set_contents: bool = False) -> None:
         decoded_content = bytestream.decode("latin1")
-        self.set_v_model(decoded_content)
+        if set_contents:
+            self.set_v_model(decoded_content)
+        else:
+            with NamedTemporaryFile(mode="w", delete=False, encoding="utf-8") as temp_file:
+                temp_file.write(decoded_content)
+                temp_file.flush()
+                self.set_v_model(temp_file.name)
 
     def select_file(self, value: str) -> None:
         """Programmatically set the v_model value."""

--- a/src/nova/trame/view/theme/assets/core_style.scss
+++ b/src/nova/trame/view/theme/assets/core_style.scss
@@ -149,6 +149,10 @@ html {
         }
     }
 
+    .v-tabs {
+        height: 32px !important;
+    }
+
     .v-tab.v-btn {
         height: 30px !important;
         min-width: fit-content !important;


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
This is needed by NeuXtalViz since input files need to be passed to Mantid, which expects file paths rather than bytestreams.

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [x] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
