### PR TITLE
Add binding support for MatplotlibFigure.figure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### nova-trame, 0.25.0
+
+* The figure parameter to MatplotlibFigure should now support bindings (thanks to John Duggan).
+
 ### nova-trame, 0.24.1
 
 * Fixed literalinclude paths in the documentation (thanks to John Duggan).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nova-trame"
-version = "0.24.1"
+version = "0.25.0"
 description = "A Python Package for injecting curated themes and custom components into Trame applications"
 authors = [
     { name = "John Duggan", email = "dugganjw@ornl.gov" },

--- a/src/nova/trame/_internal/utils.py
+++ b/src/nova/trame/_internal/utils.py
@@ -7,6 +7,13 @@ from trame_server.core import State
 from nova.mvvm._internal.utils import rgetdictvalue, rsetdictvalue
 
 
+# Trame state handlers don't work on nested properties. When writing Trame state handlers (e.g. flushState, dirty, or
+# change), we instead use the name of the top-level property. For example, "config.parameter_group_a.option_x" becomes
+# "config".
+def get_state_name(name: str) -> str:
+    return name.split(".")[0]
+
+
 # Reads a state parameter from Trame. For internal use only, if you're using this in your application you're violating
 # the MVVM framework. :)
 def get_state_param(state: State, value: Union[Any, Tuple]) -> Any:
@@ -25,6 +32,6 @@ def set_state_param(state: State, value: Union[Any, Tuple], new_value: Any = Non
                 rsetdictvalue(state, value[0], new_value)
             elif len(value) > 1:
                 rsetdictvalue(state, value[0], value[1])
-            state.dirty(value[0].split(".")[0])
+            state.dirty(get_state_name(value[0]))
 
     return get_state_param(state, value)

--- a/src/nova/trame/view/components/visualization/matplotlib_figure.py
+++ b/src/nova/trame/view/components/visualization/matplotlib_figure.py
@@ -8,7 +8,7 @@ from io import BytesIO
 from mimetypes import types_map
 from pathlib import Path
 from threading import Thread
-from typing import Any, Optional
+from typing import Any, Optional, Tuple, Union
 
 import tornado
 from aiohttp import ClientSession, WSMsgType, web
@@ -18,6 +18,8 @@ from matplotlib.figure import Figure
 from trame.app import get_server
 from trame.widgets import client, html, matplotlib
 from wslink.backends.aiohttp import WebAppServer
+
+from nova.trame._internal.utils import get_state_name, get_state_param
 
 
 class _MPLApplication(tornado.web.Application):
@@ -195,23 +197,35 @@ class MatplotlibFigure(matplotlib.Figure):
 
             return ws_server
 
-    def __init__(self, figure: Optional[Figure] = None, webagg: bool = False, **kwargs: Any) -> None:
+    def __init__(self, figure: Union[Figure, Tuple, None] = None, webagg: bool = False, **kwargs: Any) -> None:
         """Creates a Matplotlib figure in the Trame UI.
 
         Parameters
         ----------
-        figure : `altair.Chart <https://altair-viz.github.io/user_guide/generated/toplevel/altair.Chart.html#altair.Chart>`_
-            Altair chart object
-        webagg : bool
+        figure : Union[`altair.Chart <https://altair-viz.github.io/user_guide/generated/toplevel/altair.Chart.html#altair.Chart>`__, Tuple], optional
+            Altair chart object.
+        webagg : bool, optional
             If true, then the WebAgg backend for Matplotlib is used. If not, then the default Trame matplotlib plugin
-            is used.
+            is used. Note that this parameter does not supporting Trame bindings since the user experiences are
+            fundamentally different between the two options and toggling them is not considered a good idea by the
+            author of this component.
         kwargs
             Arguments to be passed to `AbstractElement <https://trame.readthedocs.io/en/latest/core.widget.html#trame_client.widgets.core.AbstractElement>`_
 
         Returns
         -------
         None
-        """
+        """  # noqa: E501
+        if isinstance(figure, tuple):
+            self._server = get_server(None, client_type="vue3")
+            self._figure = get_state_param(self._server.state, figure)
+
+            @self._server.state.change(get_state_name(figure[0]))
+            def on_change(**kwargs: Any) -> None:
+                self.update(get_state_param(self._server.state, figure))
+        else:
+            self._figure = figure
+
         self._webagg = webagg
         if webagg:
             self._port = MatplotlibFigure._get_free_port()
@@ -224,7 +238,6 @@ class MatplotlibFigure(matplotlib.Figure):
 
             self._server = get_server(None, client_type="vue3")
 
-            self._figure = figure
             self._initialized = False
 
             if not MatplotlibFigure.mpl_initialized:
@@ -233,7 +246,7 @@ class MatplotlibFigure(matplotlib.Figure):
 
             self.update()
         else:
-            super().__init__(figure, **kwargs)
+            super().__init__(self._figure, **kwargs)
 
     def update(self, figure: Optional[Figure] = None) -> None:
         if self._webagg:

--- a/tests/test_matplotlib.py
+++ b/tests/test_matplotlib.py
@@ -1,8 +1,13 @@
 """Unit tests for MatplotlibFigure."""
 
 from matplotlib.figure import Figure
+from pydantic import BaseModel, Field
+from trame.app import get_server
+from trame_server.core import Server
 
+from nova.mvvm.trame_binding import TrameBinding
 from nova.trame.view.components.visualization import MatplotlibFigure
+from nova.trame.view.theme import ThemedApp
 
 
 def test_matplotlib() -> None:
@@ -19,3 +24,34 @@ def test_matplotlib() -> None:
 
     webagg_test.update(None)
     webagg_test.update(mpl_figure)
+
+
+def test_parameter_bindings() -> None:
+    class TestModel(BaseModel):
+        class Config:
+            arbitrary_types_allowed = True
+
+        figure: Figure = Field(default=Figure())
+
+    class MyTrameApp(ThemedApp):
+        def __init__(self, server: Server = None) -> None:
+            self.server = get_server(None, client_type="vue3")
+            super().__init__(server=self.server)
+
+            self.create_binding()
+            self.create_ui()
+
+        def create_binding(self) -> None:
+            self.test_obj = TestModel()
+
+            binding = TrameBinding(self.server.state)
+            self.test_binding = binding.new_bind(self.test_obj)
+            self.test_binding.connect("test_mpl")
+
+        def create_ui(self) -> None:
+            with super().create_ui() as layout:
+                with layout.content:
+                    MatplotlibFigure(figure=("test_mpl.figure",))
+                    MatplotlibFigure(figure=("test_mpl.figure",), webagg=True)
+
+    MyTrameApp()


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
There's only one parameter here to add support for, figure. I'm strongly against binding webagg since toggling between the two would both be confusing UX and would be difficult to setup. One can always use v_if to render one or the other if they absolutely need this.

@gecage952 I'm adding you to review this since I'd like you to try this out in PV viewer. :)

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [x] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
