### PR TITLE
Add binding support for ExecutionButtons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### nova-trame, 0.25.1
+
+* ExecutionButtons now supports binding to stop_btn and download_btn parameters (thanks to John Duggan).
+
 ### nova-trame, 0.25.0
 
 * FileUpload now supports a return_contents parameter (thanks to John Duggan).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nova-trame"
-version = "0.25.0"
+version = "0.25.1"
 description = "A Python Package for injecting curated themes and custom components into Trame applications"
 authors = [
     { name = "John Duggan", email = "dugganjw@ornl.gov" },

--- a/src/nova/trame/view/components/execution_buttons.py
+++ b/src/nova/trame/view/components/execution_buttons.py
@@ -71,16 +71,20 @@ class ExecutionButtons:
                 id=f"{self.id}_run",
                 click=self.run,
             )
-            vuetify.VBtn(
-                "Stop",
-                v_if=self.stop_btn,
-                disabled=(f"{self.id}.stop_disabled",),
-                loading=(f"{self.id}.stop_in_progress",),
-                classes="mr-4",
-                id=f"{self.id}_stop",
-                prepend_icon="mdi-stop",
-                click=self.stop,
-            )
+            if self.stop_btn:
+                extra_params = {}
+                if isinstance(self.stop_btn, tuple):
+                    extra_params["v_if"] = self.stop_btn
+                vuetify.VBtn(
+                    "Stop",
+                    disabled=(f"{self.id}.stop_disabled",),
+                    loading=(f"{self.id}.stop_in_progress",),
+                    classes="mr-4",
+                    id=f"{self.id}_stop",
+                    prepend_icon="mdi-stop",
+                    click=self.stop,
+                    **extra_params,
+                )
             vuetify.VBtn(
                 "Cancel",
                 disabled=(f"{self.id}.cancel_disabled",),
@@ -91,14 +95,18 @@ class ExecutionButtons:
                 id=f"{self.id}_cancel",
                 click=self.cancel,
             )
-            vuetify.VBtn(
-                "Download Results",
-                v_if=self.download_btn,
-                disabled=(f"{self.id}.download_disabled",),
-                loading=(f"{self.id}.download_in_progress",),
-                id=f"{self.id}.download",
-                click=self.download,
-            )
+            if self.download_btn:
+                extra_params = {}
+                if isinstance(self.download_btn, tuple):
+                    extra_params["v_if"] = self.download_btn
+                vuetify.VBtn(
+                    "Download Results",
+                    disabled=(f"{self.id}.download_disabled",),
+                    loading=(f"{self.id}.download_in_progress",),
+                    id=f"{self.id}.download",
+                    click=self.download,
+                    **extra_params,
+                )
 
     async def download(self) -> None:
         content = await self.view_model.prepare_results()

--- a/src/nova/trame/view/components/execution_buttons.py
+++ b/src/nova/trame/view/components/execution_buttons.py
@@ -1,5 +1,7 @@
 """Module for the Progress Tab."""
 
+from typing import Tuple, Union
+
 from trame.app import get_server
 from trame.widgets import client
 from trame.widgets import vuetify3 as vuetify
@@ -15,16 +17,17 @@ class ExecutionButtons:
     This is intended to be used with the `nova-galaxy ToolRunner <https://nova-application-development.readthedocs.io/projects/nova-galaxy/en/latest/core_concepts/tool_runner.html>`__.
     """
 
-    def __init__(self, id: str, stop_btn: bool = False, download_btn: bool = False) -> None:
+    def __init__(self, id: str, stop_btn: Union[bool, Tuple] = False, download_btn: Union[bool, Tuple] = False) -> None:
         """Constructor for ExecutionButtons.
 
         Parameters
         ----------
         id : str
-            Component id. Should be used consistently with ToolRunner and other components.
-        stop_btn: bool
+            Component id. Should be used consistently with ToolRunner and other components. Note that this parameter
+            does not support Trame bindings.
+        stop_btn: Union[bool, Tuple]
             Display stop button.
-        download_btn : bool
+        download_btn : Union[bool, Tuple]
             Display download button.
 
         Returns
@@ -68,16 +71,16 @@ class ExecutionButtons:
                 id=f"{self.id}_run",
                 click=self.run,
             )
-            if self.stop_btn:
-                vuetify.VBtn(
-                    "Stop",
-                    disabled=(f"{self.id}.stop_disabled",),
-                    loading=(f"{self.id}.stop_in_progress",),
-                    classes="mr-4",
-                    id=f"{self.id}_stop",
-                    prepend_icon="mdi-stop",
-                    click=self.stop,
-                )
+            vuetify.VBtn(
+                "Stop",
+                v_if=self.stop_btn,
+                disabled=(f"{self.id}.stop_disabled",),
+                loading=(f"{self.id}.stop_in_progress",),
+                classes="mr-4",
+                id=f"{self.id}_stop",
+                prepend_icon="mdi-stop",
+                click=self.stop,
+            )
             vuetify.VBtn(
                 "Cancel",
                 disabled=(f"{self.id}.cancel_disabled",),
@@ -88,14 +91,14 @@ class ExecutionButtons:
                 id=f"{self.id}_cancel",
                 click=self.cancel,
             )
-            if self.download_btn:
-                vuetify.VBtn(
-                    "Download Results",
-                    disabled=(f"{self.id}.download_disabled",),
-                    loading=(f"{self.id}.download_in_progress",),
-                    id=f"{self.id}.download",
-                    click=self.download,
-                )
+            vuetify.VBtn(
+                "Download Results",
+                v_if=self.download_btn,
+                disabled=(f"{self.id}.download_disabled",),
+                loading=(f"{self.id}.download_in_progress",),
+                id=f"{self.id}.download",
+                click=self.download,
+            )
 
     async def download(self) -> None:
         content = await self.view_model.prepare_results()

--- a/src/nova/trame/view/components/progress_bar.py
+++ b/src/nova/trame/view/components/progress_bar.py
@@ -20,7 +20,8 @@ class ProgressBar:
         Parameters
         ----------
         id : str
-            Component id. Should be used consistently with ToolRunner and other components
+            Component id. Should be used consistently with ToolRunner and other components. Note that this parameter
+            does not support Trame bindings.
 
         Returns
         -------

--- a/src/nova/trame/view/components/tool_outputs.py
+++ b/src/nova/trame/view/components/tool_outputs.py
@@ -21,7 +21,8 @@ class ToolOutputWindows:
         Parameters
         ----------
         id : str
-            Component id. Should be used consistently with ToolRunner and other components
+            Component id. Should be used consistently with ToolRunner and other components. Note that this parameter
+            does not support Trame bindings.
 
         Returns
         -------

--- a/tests/gallery/views/app.py
+++ b/tests/gallery/views/app.py
@@ -508,6 +508,7 @@ class App(ThemedApp):
 
                     ToolOutputWindows("test")
                     ExecutionButtons("test")
+                    ExecutionButtons("test_bindings", stop_btn=("true",), download_btn=False)
 
             with layout.post_content:
                 html.Div("Sticky Bottom Content", classes="text-center w-100")


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
Added the ability to bind to stop_btn and download_btn. These just control button visibility, so I made use of v_if to conditionally render them when using bindings (not sure why one would want to do this, but it's easy enough to support).

There's nothing useful to bind in ToolOutputs and ProgressBar (one shouldn't be dynamically modifying the element id), so I've just added notes on those parameters that they don't support binding.

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [x] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->

Closes #120
Closes #122 
Closes #124 
