### PR TITLE
Support range selection in DataSelector and NeutronDataSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### nova-trame, 0.27.0
+
+* DataSelector and NeutronDataSelector support range selection via Shift+Click (thanks to John Duggan).
+
 ### nova-trame, 0.26.0
 
 * Added data_source and projection parameters to NeutronDataSelector to allow populating data files from ONCat (thanks to Andrew Ayres and John Duggan).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nova-trame"
-version = "0.26.0"
+version = "0.27.0"
 description = "A Python Package for injecting curated themes and custom components into Trame applications"
 authors = [
     { name = "John Duggan", email = "dugganjw@ornl.gov" },


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
You can now hold Shift while selecting in DataSelector/NeutronDataSelector to select a range of files. Shift click only works if the most recent action was selecting an item. It should work in both directions (shift click on a file above or below the previously selected item). It should also avoid adding duplicate selections of a file if it's in the selected range but already in the selected files list.

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [x] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
