### PR TITLE
Fix vertical alignment of revogrid header in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### nova-trame, 1.2.2
+
+* Fixes a DataSelector rendering bug in Safari (thanks to John Duggan).
+
 ### nova-trame, 1.2.1
 
 * Fixes a vertical alignment issue with NeutronDataSelector when the component is placed in a relatively low-width container (thanks to John Duggan).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nova-trame"
-version = "1.2.1"
+version = "1.2.2"
 description = "A Python Package for injecting curated themes and custom components into Trame applications"
 authors = [
     { name = "John Duggan", email = "dugganjw@ornl.gov" },

--- a/src/nova/trame/view/theme/assets/js/revo_grid.js
+++ b/src/nova/trame/view/theme/assets/js/revo_grid.js
@@ -133,7 +133,7 @@ class RevoGrid {
             extensions_text = ` (${extensions.join(',')})`
         }
 
-        const header = createElement('div', {'class': 'd-flex'}, inputVNode, `Available Datafiles${extensions_text}`)
+        const header = createElement('div', {'class': 'align-center d-flex'}, inputVNode, `Available Datafiles${extensions_text}`)
 
         let controls = null
         if (availableData.length < 1) {


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
align-items in the RevoGrid header was receiving a different default in Safari vs Firefox and Chrome. I've set the class explicitly to address the issue.

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [x] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
