### PR TITLE
Fix VIcon sizes not applying

### DIFF
--- a/src/nova/trame/view/theme/assets/core_style.scss
+++ b/src/nova/trame/view/theme/assets/core_style.scss
@@ -1,7 +1,10 @@
 /* Global font sizes can't be set through the Vuetify configuration. */
 .v-theme--CompactTheme {
     $primary-color: #007833;
-    font-size: 0.75rem;
+
+    &:not(.v-icon) {
+        font-size: 0.75rem;
+    }
 
     html {
         overflow-y: auto;

--- a/src/nova/trame/view/theme/assets/vuetify_config.json
+++ b/src/nova/trame/view/theme/assets/vuetify_config.json
@@ -58,6 +58,9 @@
             "color": "primary",
             "prependIcon": false
         },
+        "VIcon": {
+            "size": "small"
+        },
         "VLabel": {
             "style": {
                 "opacity": 1.0

--- a/tests/gallery/views/app.py
+++ b/tests/gallery/views/app.py
@@ -428,7 +428,7 @@ class ComponentTab:
             with GridLayout(columns=3, halign="center", valign="center"):
                 vuetify.VAlert("Alert")
                 with vuetify.VBadge():
-                    vuetify.VIcon("mdi-ab-testing")
+                    vuetify.VIcon("mdi-ab-testing", size="x-large")
                 vuetify.VProgressCircular(indeterminate=True)
                 vuetify.VProgressLinear(indeterminate=True)
                 with vuetify.VSnackbar(


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
Minor bugfix that allows setting icon size via `VIcon(size="large")`. This was being overridden by our global font size so one had to use a numeric size to have it take effect. To keep default icon sizes as close as possible to the current default, I've added a default icon size of `small` in our Vuetify configuration.

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [x] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
