### PR TITLE
166 allow setting the stretch parameter on children of our layout components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-### nova-trame, 1.8.0 (unreleased)
+### nova-trame, 1.8.0
 
 * Adds `nova.trame.get_app` to make it easier to access `ThemedApp` methods from child components (thanks to John Duggan).
 * `InputField` now supports `type="button"` for creating buttons (thanks to John Duggan).
 * `InputField` automatically visually indicates required fields in Pydantic (thanks to John Duggan).
+* Children of `GridLayout`, `HBoxLayout`, and `VBoxLayout` can now override the `halign`, `valign`, and `stretch` parameters (thanks to John Duggan).
 
 ### nova-trame, 1.7.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nova-trame"
-version = "1.7.1"
+version = "1.8.0"
 description = "A Python Package for injecting curated themes and custom components into Trame applications"
 authors = [
     { name = "John Duggan", email = "dugganjw@ornl.gov" },

--- a/src/nova/trame/view/layouts/grid.py
+++ b/src/nova/trame/view/layouts/grid.py
@@ -160,6 +160,11 @@ class GridLayout(html.Div):
         if isinstance(child, str):
             child = html.Div(child)
 
+        if "style" not in child._py_attr or child.style is None:
+            child.style = ""
+        if "classes" not in child._py_attr or child.classes is None:
+            child.classes = ""
+
         row_span = 1
         column_span = 1
         if "row_span" in child._py_attr:
@@ -167,12 +172,17 @@ class GridLayout(html.Div):
         if "column_span" in child._py_attr:
             column_span = child._py_attr["column_span"]
 
-        if "style" not in child._py_attr or child.style is None:
-            child.style = ""
         child.style += f"; {self.get_row_style(row_span)} {self.get_column_style(column_span)}"
-
-        if "classes" not in child._py_attr or child.classes is None:
-            child.classes = ""
         child.classes += " d-grid-item"
+
+        if "halign" in child._py_attr:
+            child.style += f" justify-self: {child.halign};"
+        if "stretch" in child._py_attr:
+            if child.stretch:
+                child.classes += " flex-1-1"
+            else:
+                child.classes += " flex-0-1"
+        if "valign" in child._py_attr:
+            child.style += f" align-self: {child.valign};"
 
         super().add_child(child)

--- a/src/nova/trame/view/layouts/hbox.py
+++ b/src/nova/trame/view/layouts/hbox.py
@@ -1,8 +1,10 @@
 """Trame implementation of the HBoxLayout class."""
 
 from typing import Any, Optional, Union
+from warnings import warn
 
 from trame.widgets import html
+from trame_client.widgets.core import AbstractElement
 
 from .utils import merge_styles
 
@@ -110,3 +112,61 @@ class HBoxLayout(html.Div):
             styles["margin-bottom"] = vspace
 
         return styles
+
+    def add_child(self, child: Union[AbstractElement, str]) -> AbstractElement:
+        """Add a child to the box.
+
+        Do not call this directly. Instead, use Trame's `with` syntax, which will call this method internally. This
+        method is documented here as a reference for the halign, stretch, and valign parameters.
+
+        Parameters
+        ----------
+        child : `AbstractElement \
+            <https://trame.readthedocs.io/en/latest/core.widget.html#trame_client.widgets.core.AbstractElement>`_ | str
+            The child to add to the grid.
+        halign : str
+            NOTE: This parameter is valid at the box level but not for individual elements due to limitations in the CSS
+            flexbox. Instead, you can use `VSpacer <https://trame.readthedocs.io/en/latest/trame.widgets.vuetify3.html>`__
+            to add horizontal space between elements.
+        stretch : bool
+            Allows overriding the stretch parameter declared at the box level for a single child.
+        valign : str
+            Allows overriding the vertical alignment declared at the box level for a single child.
+
+        Returns
+        -------
+        None
+
+        Example
+        -------
+        .. literalinclude:: ../tests/gallery/views/app.py
+            :start-after: grid row and column span example
+            :end-before: grid row and column span example end
+            :dedent:
+        """
+        if isinstance(child, str):
+            child = html.Div(child)
+
+        if "style" not in child._py_attr or child.style is None:
+            child.style = ""
+        if "classes" not in child._py_attr or child.classes is None:
+            child.classes = ""
+
+        if "halign" in child._py_attr:
+            warn(
+                (
+                    "halign cannot change the horizontal alignment of individual elements in an HBoxLayout due to "
+                    "limitations in the CSS flexbox. Instead, use `trame.widgets.vuetify3.VSpacer` in between your "
+                    "elements to manipulate horizontal alignment."
+                ),
+                stacklevel=1,
+            )
+        if "stretch" in child._py_attr:
+            if child.stretch:
+                child.classes += " flex-1-1"
+            else:
+                child.classes += " flex-0-1"
+        if "valign" in child._py_attr:
+            child.style += f" align-self: {child.valign};"
+
+        super().add_child(child)

--- a/src/nova/trame/view/layouts/vbox.py
+++ b/src/nova/trame/view/layouts/vbox.py
@@ -1,8 +1,10 @@
 """Trame implementation of the VBoxLayout class."""
 
 from typing import Any, Optional, Union
+from warnings import warn
 
 from trame.widgets import html
+from trame_client.widgets.core import AbstractElement
 
 from .utils import merge_styles
 
@@ -110,3 +112,61 @@ class VBoxLayout(html.Div):
             styles["margin-bottom"] = vspace
 
         return styles
+
+    def add_child(self, child: Union[AbstractElement, str]) -> AbstractElement:
+        """Add a child to the box.
+
+        Do not call this directly. Instead, use Trame's `with` syntax, which will call this method internally. This
+        method is documented here as a reference for the halign, stretch, and valign parameters.
+
+        Parameters
+        ----------
+        child : `AbstractElement \
+            <https://trame.readthedocs.io/en/latest/core.widget.html#trame_client.widgets.core.AbstractElement>`_ | str
+            The child to add to the grid.
+        halign : str
+            Allows overriding the horizontal alignment declared at the box level for a single child.
+        stretch : bool
+            Allows overriding the stretch parameter declared at the box level for a single child.
+        valign : str
+            NOTE: This parameter is valid at the box level but not for individual elements due to limitations in the CSS
+            flexbox. Instead, you can use `VSpacer <https://trame.readthedocs.io/en/latest/trame.widgets.vuetify3.html>`__
+            to add vertical space between elements.
+
+        Returns
+        -------
+        None
+
+        Example
+        -------
+        .. literalinclude:: ../tests/gallery/views/app.py
+            :start-after: grid row and column span example
+            :end-before: grid row and column span example end
+            :dedent:
+        """
+        if isinstance(child, str):
+            child = html.Div(child)
+
+        if "style" not in child._py_attr or child.style is None:
+            child.style = ""
+        if "classes" not in child._py_attr or child.classes is None:
+            child.classes = ""
+
+        if "halign" in child._py_attr:
+            child.style += f" align-self: {child.halign};"
+        if "stretch" in child._py_attr:
+            if child.stretch:
+                child.classes += " flex-1-1"
+            else:
+                child.classes += " flex-0-1"
+        if "valign" in child._py_attr:
+            warn(
+                (
+                    "valign cannot change the vertical alignment of individual elements in a VBoxLayout due to "
+                    "limitations in the CSS flexbox. Instead, use `trame.widgets.vuetify3.VSpacer` in between your "
+                    "elements to manipulate vertical alignment."
+                ),
+                stacklevel=1,
+            )
+
+        super().add_child(child)

--- a/tests/gallery/views/app.py
+++ b/tests/gallery/views/app.py
@@ -89,6 +89,26 @@ class MplTest:
         ax.plot(t, s)
 
 
+class AlignmentTab:
+    """Tab for testing element self-alignment."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.create_ui(**kwargs)
+
+    def create_ui(self, **kwargs: Any) -> None:
+        with VBoxLayout(stretch=True, **kwargs):
+            InputField(label="No Stretch", stretch=False)
+            InputField(label="Stretch")
+        with HBoxLayout(stretch=True, **kwargs):
+            InputField(text="Top Left", type="button", valign="start")
+            vuetify.VSpacer()
+            InputField(text="Bottom Right", type="button", valign="end")
+        with VBoxLayout(stretch=True, **kwargs):
+            InputField(text="Top Left", halign="start", type="button")
+            vuetify.VSpacer()
+            InputField(text="Bottom Right", halign="end", type="button")
+
+
 class ComponentTab:
     """Tab for holding the component gallery."""
 
@@ -555,10 +575,12 @@ class App(ThemedApp):
                     with vuetify.VTabs(v_model="config.active_tab", classes="pl-6"):
                         vuetify.VTab("Components", value=0)
                         vuetify.VTab("Full-screen Layout", value=1)
+                        vuetify.VTab("Alignment Tests", value=2)
 
             with layout.content:
                 ComponentTab(self.config_vm, self.local_storage, v_if="config.active_tab == 0")
                 FullScreenTab(v_if="config.active_tab == 1")
+                AlignmentTab(v_if="config.active_tab == 2")
 
             with layout.post_content:
                 html.Div("Sticky Bottom Content", classes="text-center w-100")


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
I've added support to our layout components to allow individual items to self-align and self-stretch. This should make it easier to create cleaner code in the future.

Note that our box layouts cannot allow self alignment along their main axis (e.g. HBoxLayout children can't self align horizontally) due to limitations of the flexbox: https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Box_alignment/In_flexbox#there_is_no_justify-self_in_flexbox

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [x] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
